### PR TITLE
Фикс случайного NullPointerException в сервисах криптографии

### DIFF
--- a/src/main/java/ru/obninsk/iate/easycipher/lib/services/AesCryptoService.java
+++ b/src/main/java/ru/obninsk/iate/easycipher/lib/services/AesCryptoService.java
@@ -102,9 +102,11 @@ public class AesCryptoService implements ICryptoService {
             while (totalBytesRead < dataSize && (bytesRead = inputStream.read(buffer)) != -1) {
                 int bytesToProcess = (int) Math.min(bytesRead, dataSize - totalBytesRead);
                 byte[] decrypted = cipher.update(buffer, 0, bytesToProcess);
-                totalDecryptedBytes += decrypted.length;
-                messageDigest.update(decrypted);
-                outputStream.write(decrypted);
+                if (decrypted != null) {
+                    totalDecryptedBytes += decrypted.length;
+                    messageDigest.update(decrypted);
+                    outputStream.write(decrypted);
+                }
                 totalBytesRead += bytesToProcess;
             }
 

--- a/src/main/java/ru/obninsk/iate/easycipher/lib/services/BlowfishCryptoService.java
+++ b/src/main/java/ru/obninsk/iate/easycipher/lib/services/BlowfishCryptoService.java
@@ -118,9 +118,11 @@ public class BlowfishCryptoService implements ICryptoService {
             while (totalBytesRead < dataSize && (bytesRead = inputStream.read(buffer)) != -1) {
                 int bytesToProcess = (int) Math.min(bytesRead, dataSize - totalBytesRead);
                 byte[] decrypted = cipher.update(buffer, 0, bytesToProcess);
-                totalDecryptedBytes += decrypted.length;
-                messageDigest.update(decrypted);
-                outputStream.write(decrypted);
+                if (decrypted != null) {
+                    totalDecryptedBytes += decrypted.length;
+                    messageDigest.update(decrypted);
+                    outputStream.write(decrypted);
+                }
                 totalBytesRead += bytesToProcess;
             }
 

--- a/src/main/java/ru/obninsk/iate/easycipher/lib/services/TwofishCryptoService.java
+++ b/src/main/java/ru/obninsk/iate/easycipher/lib/services/TwofishCryptoService.java
@@ -121,9 +121,11 @@ public class TwofishCryptoService implements ICryptoService {
             while (totalBytesRead < dataSize && (bytesRead = inputStream.read(buffer)) != -1) {
                 int bytesToProcess = (int) Math.min(bytesRead, dataSize - totalBytesRead);
                 byte[] decrypted = cipher.update(buffer, 0, bytesToProcess);
-                totalDecryptedBytes += decrypted.length;
-                messageDigest.update(decrypted);
-                outputStream.write(decrypted);
+                if (decrypted != null) {
+                    totalDecryptedBytes += decrypted.length;
+                    messageDigest.update(decrypted);
+                    outputStream.write(decrypted);
+                }
                 totalBytesRead += bytesToProcess;
             }
 


### PR DESCRIPTION
Проблема была иключительно с маленькими файлами, длина которых меньше размера блока алгоритма, т.е. 16 байт. Например, в "hello world" было 12 байт. Все сделали проверку на null результата cipher.update в методе шифрования, но никто не сделал этого же в методе дешифрования. В итоге когда размер файла меньше блока алгоритма, то cipher.update всегда выдает null, т.к. обработка такого блока (чтобы убрать дополнение) происходит в cipher.doFinal. По итогу в цикле получался null, и дальше этот null гулял там и сям, оттого и проблема.

Closes #19 